### PR TITLE
Add instructions for installing make/git

### DIFF
--- a/tutorial/Chapter 1.md
+++ b/tutorial/Chapter 1.md
@@ -40,7 +40,18 @@ The environment required to build software for the Wii U (more specifically, usi
 
 Please note that while devkitPPC is supported on Windows, wut is not. If you wish to use Windows to perform development activity, you may wish to install Ubuntu or another GNU/Linux distribution from the Microsoft Store app, and perform these instructions within the virtualised Linux subsystem. If you natively use a GNU/Linux distribution or macOS, you should be able to follow these instructions.
 
-### Step 1: Install CMake
+### Step 1: Standard compiling environment
+In order to build software for the Wii U, you will need a few essential build tools, namely GNU `make` and probably `git` too.
+On GNU/Linux distributions, your package manager likely includes a way to install GNU `make` easily. In fact, some vendors will provide a group of packages related to software development. But for our use case, just `make` and `git` is enough. So, for Debian-based systems, you could use:
+```
+$ sudo apt-get update
+$ sudo apt-get install make git
+```
+If you're using a different GNU/Linux distribution, you may need to adapt the above command to your platform's native package manager.
+
+On macOS, the easiest way to acquire `make` and `git` is to install the Xcode Command Line Tools. To do this, simply open a terminal and try to run `make`. You will be immediately prompted to install the Command Line Tools. You do not need to install the full Xcode IDE from the Mac App Store, only the Command Line Tools are necessary.
+
+### Step 2: Install CMake
 CMake is a tool that is used to generate build files for a project (e.g. a Makefile, Visual Studio project file, etc.) from a higher-level scripting language. CMake is a core part of the wut build system, and for most software that uses wut, CMake is required to perform the build.
 
 CMake is well supported by package vendors and is easy to install. On a GNU/Linux distribution, you can usually install it using your platform's package manager, e.g. for Debian/Ubuntu/Raspbian/etc. -
@@ -52,12 +63,12 @@ $ sudo apt-get install cmake
 
 On macOS, if you have [Homebrew](https://brew.sh/) or [MacPorts](https://macports.org/) installed, you can install it using the respective command line tools. Otherwise, CMake is available as a graphical installer from https://cmake.org/download/ (scroll down to "Binary distributions").
 
-### Step 2: Install the devkitPro package manager
+### Step 3: Install the devkitPro package manager
 The devkitPPC compiler toolchain is part of a larger set of software programs called devkitPro, which provides toolchains for development of homebrew for platforms such as the Nintendo 3DS, Switch, GameCube and Wii, as well as others. As such, devkitPro has its own package manager, `dkp-pacman`, which can be installed relatively easily, and can be used to configure the development environment to your liking.
 
 For people using macOS or a Debian-based GNU/Linux distribution (e.g. Ubuntu, Raspbian) `dkp-pacman` can be installed by downloading and running the installer from its [download page](https://github.com/devkitPro/pacman/releases/latest). For other GNU/Linux distributions (especially Arch), you may already have the standard `pacman` installed, or you may be able to install `pacman`, which can be configured to read from the devkitPro repositories, as per the instructions on the [devkitPro wiki](https://devkitpro.org/wiki/devkitPro_pacman).
 
-### Step 3: Install devkitPPC and other tools
+### Step 4: Install devkitPPC and other tools
 Now that `dkp-pacman` is installed (or you've configured `pacman` to search the devkitPro repositories) make sure that the list of packages is up-to-date.
 
 (Note: make sure that you use the correct program for your system - `dkp-pacman` or the standard `pacman`)
@@ -92,12 +103,12 @@ export DEVKITPPC=$DEVKITPRO/devkitPPC
 export PATH=$DEVKITPPC/bin:$DEVKITPRO/tools/bin:$PATH
 ```
 
-### Step 4: Set up Fling (Wii U-specific package repository)
+### Step 5: Set up Fling (Wii U-specific package repository)
 In addition to the official devkitPro software packages, we have our own package repository (fling.heyquark.com) which contains many packages specific to Wii U development.
 
 The process of setting up Fling is documented on its [GitLab repository page](https://gitlab.com/QuarkTheAwesome/wiiu-fling/blob/master/README.md#wiiu-fling).
 
-### Step 5: Installing wut
+### Step 6: Installing wut
 With Fling installed, installing wut is very easy.
 
 For GNU/Linux and Windows Subsystem for Linux users:


### PR DESCRIPTION
I had a weird feeling that I was forgetting something. Turns out I was.

It's true that you need CMake to build with most wut software, but you also need GNU Make! And probably Git too.

(Once msys wut gets a release I'll update the instructions to include msys instructions)